### PR TITLE
V1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,26 +98,27 @@ val xweatherAccount = XweatherAccount(
 Add MapsGL layers to the map:
 ```
 // Example Sample Layer:
-val temperaturesLayer = mapController.addWeatherLayer("temperatures")
-temperaturesLayer.let{
-	val sPaint = it.paint as SampleStyle
-	sPaint.opacity = 1.00f
-	sPaint.quality = DataQuality.normal
-}
+mapController.addWeatherLayer(WeatherService.Temperatures(mapController.service).apply {
+    with(layer.paint as SampleStyle) {
+        opacity = 1.0f
+    }
+})
 
 //Example Particle Layer:
-val windParticleLayer= mapController.addWeatherLayer("wind-layer")
-windParticleLayer?.let{
-	val pPaint = it.paint as ParticleStyle
-        pPaint.opacity=1.0f
-        pPaint.density = ParticleDensity.NORMAL
-        pPaint.speedFactor = 1f
-        pPaint.trails = true
-        pPaint.trailsFadeFactor = ParticleTrailLength.NORMAL
-        pPaint.size = 2.0f
-}
+mapController.addWeatherLayer(WeatherService.WindParticles(mapController.service).apply {
+    with(layer.paint as ParticleStyle) {
+        opacity=1.0f
+        density = ParticleDensity.NORMAL
+        speedFactor = 1f
+        trails = true
+        trailsFadeFactor = ParticleTrailLength.NORMAL
+        size = 2.0f
+    }
+})
 ```
+
 Create your MapboxController:
+
 ```
 binding.mapView.viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener{
 	override fun onGlobalLayout() {

--- a/app/src/main/java/com/example/mapsgldemo/LayerButtonView.kt
+++ b/app/src/main/java/com/example/mapsgldemo/LayerButtonView.kt
@@ -13,8 +13,9 @@ import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import com.xweather.mapsgl.config.weather.WeatherService
 
-class LayerButtonView(context: Context, title: String, val id: String /*val classHolder: KClass<*>*/, /*service: WeatherService.WeatherLayerConfiguration,*/ status: Int = 0) : LinearLayout(context) {
+class LayerButtonView(context: Context, title: String, val configuration: WeatherService.WeatherLayerConfiguration /*val classHolder: KClass<*>*/, /*service: WeatherService.WeatherLayerConfiguration,*/ status: Int = 0) : LinearLayout(context) {
     private val textView: TextView
     var active = false
 

--- a/app/src/main/java/com/example/mapsgldemo/MainActivity.kt
+++ b/app/src/main/java/com/example/mapsgldemo/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import android.view.ViewTreeObserver
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.ui.graphics.Color
 import com.example.mapsgldemo.LayerButtonView.Companion.createHeadingTextView
 import com.example.mapsgldemo.databinding.ActivityMainBinding
 import com.mapbox.maps.MapLoadedCallback
@@ -17,13 +18,16 @@ import com.mapbox.maps.extension.style.projection.generated.setProjection
 import com.mapbox.maps.extension.style.sources.addSource
 import com.mapbox.maps.extension.style.sources.generated.geoJsonSource
 import com.mapbox.maps.plugin.scalebar.scalebar
-import com.xweather.mapsglmaps.config.weather.account.XweatherAccount
-import com.xweather.mapsglmaps.layers.style.ParticleStyle
-import com.xweather.mapsglmaps.layers.style.RasterStyle
-import com.xweather.mapsglmaps.layers.style.SampleStyle
-import com.xweather.mapsglmaps.map.mapbox.MapboxMapController
-import com.xweather.mapsglmaps.style.ParticleDensity
-import com.xweather.mapsglmaps.style.ParticleTrailLength
+import com.xweather.mapsgl.config.weather.WeatherService
+import com.xweather.mapsgl.layers.style.SampleStyle
+import com.xweather.mapsgl.weather.groups.ColorStop
+import com.xweather.mapsgl.config.weather.account.XweatherAccount
+import com.xweather.mapsgl.layers.style.ParticleStyle
+import com.xweather.mapsgl.layers.style.RasterStyle
+import com.xweather.mapsgl.map.mapbox.MapboxMapController
+import com.xweather.mapsgl.style.ParticleDensity
+import com.xweather.mapsgl.style.ParticleTrailLength
+
 
 class MainActivity : AppCompatActivity() {
     private lateinit var mapView: MapView
@@ -38,7 +42,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        isTablet=LayerButtonView.isTablet(baseContext)
+        isTablet = LayerButtonView.isTablet(baseContext)
 
         xweatherAccount = XweatherAccount( //You can store account info in res\values\strings.xml
             getString(R.string.xweather_client_id),
@@ -47,32 +51,33 @@ class MainActivity : AppCompatActivity() {
 
         binding = ActivityMainBinding.inflate(layoutInflater)
 
-        //Create menu buttons for all the available layers
-        createLayerButtons()
-
         val mapLoadedCallback = MapLoadedCallback {
+
+            // Create menu buttons for all the available layers
+            createLayerButtons()
+
             for (customView in layerButtonList) {
                 if (customView is LayerButtonView) { // Add layer button
                     customView.outerView.setOnClickListener {
                         customView.click()
                         if (customView.active) {
-                            mapController.addWeatherLayer(customView.id)
+                            mapController.addWeatherLayer(customView.configuration)
 
                             // Customize satellite raster layer
-                            if(customView.id == "satellite"){
-                                val rPaint = mapController.getLayer(customView.id)!!.paint as RasterStyle
+                            if(customView.configuration.layer.id == "satellite"){
+                                val rPaint = mapController.getLayer(customView.configuration.layer.id)!!.paint as RasterStyle
                                 rPaint.opacity = .6f
                             }
 
                             // Customize temperatures sample layer
-                            if (customView.id == "temperatures") {
-                                val sPaint = mapController.getLayer(customView.id)!!.paint as SampleStyle
-                                sPaint.opacity = 1.00f
+                            else if (customView.configuration.layer.id == "temperatures") {
+                                val sPaint = mapController.getLayer(customView.configuration.layer.id)!!.paint as SampleStyle
+                                sPaint.opacity = .40f
                             }
 
                             // Customize wind-particles particle layer
-                            if (customView.id == "wind-particles") {
-                                val pPaint = mapController.getLayer(customView.id)!!.paint as ParticleStyle
+                            else if (customView.configuration.layer.id == "wind-particles") {
+                                val pPaint = mapController.getLayer(customView.configuration.layer.id)!!.paint as ParticleStyle
                                 pPaint.opacity = 1.0f
                                 pPaint.density = ParticleDensity.NORMAL
                                 pPaint.speedFactor = 1f
@@ -81,7 +86,7 @@ class MainActivity : AppCompatActivity() {
                                 pPaint.size = 2.0f
                             }
                         }
-                        mapController.setLayerVisible(customView.id, customView.active)
+                        mapController.setLayerVisible(customView.configuration.layer.id, customView.active)
                         mapController.mapboxMap.triggerRepaint()
                     }
                 }
@@ -136,8 +141,25 @@ class MainActivity : AppCompatActivity() {
 
             layerMenuButton.setOnClickListener {
                 LayerButtonView.showDatasetButtons(true, binding.layerConstraintLayout, binding.layerMenuButton)
-                //mapView.scalebar.enabled = false
                 showLayerMenu = true
+
+                val customColors: List<ColorStop> = listOf(
+                    // The first value is temperature in degrees Celcius
+                    // The color values are red, green, blue, alpha
+                    ColorStop(-62.22, Color(0.0f, 0.0f, 0.0f, 1.0f)),
+                    ColorStop(12.11, Color(0.0f, 0.0f, 1.0f, 1.0f)),
+                    ColorStop(26.00, Color(1.0f, 0.0f, 0.0f, 1.0f)),
+                    ColorStop(34.44, Color(1.0f, 1.0f, 1.0f, 1.0f)),
+                )
+
+                mapController.addWeatherLayer(
+                    com.xweather.mapsgl.config.weather.WeatherService.Temperatures(mapController.service).apply {
+                        with(layer.paint as SampleStyle) {
+                            opacity = 1.0f
+                            colorScale.stops = customColors
+                        }
+                    }
+                )
             }
 
             binding.layerCloseButton.setOnClickListener{
@@ -148,65 +170,64 @@ class MainActivity : AppCompatActivity() {
 
     private fun createLayerButtons(){
         layerButtonList.add(createHeadingTextView("Conditions", baseContext))
-        layerButtonList.add(LayerButtonView(baseContext, "Temperatures", "temperatures"))
-        layerButtonList.add(LayerButtonView(baseContext, "24hr Temp Change", "temperatures-24hr-change"))
-        layerButtonList.add(LayerButtonView(baseContext, "1hr Temp Change", "temperatures-1hr-change"))
-        layerButtonList.add(LayerButtonView(baseContext, "Feels Like", "feels-like"))
-        layerButtonList.add(LayerButtonView(baseContext, "Heat Index", "heat-index"))
-        layerButtonList.add(LayerButtonView(baseContext, "Wind Chill", "wind-chill"))
-        layerButtonList.add(LayerButtonView(baseContext, "Winds", "wind-speeds"))
-        layerButtonList.add(LayerButtonView(baseContext, "Wind Particles", "wind-particles"))
-        layerButtonList.add(LayerButtonView(baseContext, "Wind Gusts", "wind-gusts"))
-        layerButtonList.add(LayerButtonView(baseContext, "Dew Point", "dew-points"))
-        layerButtonList.add(LayerButtonView(baseContext, "Humidity", "humidity"))
-        layerButtonList.add(LayerButtonView(baseContext, "MSLP", "pressure-msl"))
-        layerButtonList.add(LayerButtonView(baseContext, "Cloud Cover", "cloud-cover"))
-        layerButtonList.add(LayerButtonView(baseContext, "Precipitation", "precip"))
-        layerButtonList.add(LayerButtonView(baseContext, "Snow Depth", "snow-depth"))
-        layerButtonList.add(LayerButtonView(baseContext, "Visibility", "visibility"))
-        layerButtonList.add(LayerButtonView(baseContext, "UV Index", "uvi"))
-        layerButtonList.add(LayerButtonView(baseContext, "Radar", "radar"))
+        layerButtonList.add(LayerButtonView(baseContext, "Temperatures", com.xweather.mapsgl.config.weather.WeatherService.Temperatures(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "24hr Temp Change", WeatherService.Temperatures24HourChange(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "1hr Temp Change", WeatherService.Temperatures1HourChange(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Feels Like", WeatherService.FeelsLike(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Heat Index",  WeatherService.HeatIndex(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Wind Chill",  WeatherService.WindChill(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Winds",  WeatherService.WindSpeeds(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Wind Particles",  WeatherService.WindParticles(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Wind Gusts",  WeatherService.WindGusts(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Dew Point", WeatherService.Dewpoint(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Humidity", WeatherService.Humidity(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "MSLP", WeatherService.PressureMeanSeaLevel(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Cloud Cover", WeatherService.CloudCover(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Precipitation", WeatherService.Precipitation(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Snow Depth", WeatherService.SnowDepth(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Visibility", WeatherService.Visibility(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "UV Index", WeatherService.UVIndex(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Radar", WeatherService.Radar(mapController.service)))
 
         layerButtonList.add(createHeadingTextView("Raster", baseContext))
-        layerButtonList.add(LayerButtonView(baseContext, "Satellite", "satellite"))
-        layerButtonList.add(LayerButtonView(baseContext, "Satellite GeoColor", "satellite-geocolor"))
-        layerButtonList.add(LayerButtonView(baseContext, "Satellite Visible", "satellite-visible"))
-        layerButtonList.add(LayerButtonView(baseContext, "Satellite Infrared Color", "satellite-infrared-color"))
-        layerButtonList.add(LayerButtonView(baseContext, "Satellite Water Vapor", "satellite-water-vapor"))
-
+        layerButtonList.add(LayerButtonView(baseContext, "Satellite", WeatherService.Satellite(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Satellite GeoColor", WeatherService.SatelliteGeoColor(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Satellite Visible", WeatherService.SatelliteVisible(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Satellite Infrared Color", WeatherService.SatelliteInfraredColor(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Satellite Water Vapor", WeatherService.SatelliteWaterVapor(mapController.service)))
         layerButtonList.add(createHeadingTextView("Maritime", baseContext))
-        layerButtonList.add(LayerButtonView(baseContext, "Sea Surface Temps", "sst"))
-        layerButtonList.add(LayerButtonView(baseContext, "Currents: Fill", "ocean-currents"))
-        layerButtonList.add(LayerButtonView(baseContext, "Currents: Particles", "ocean-currents.particles"))
-        layerButtonList.add(LayerButtonView(baseContext, "Wave Heights", "wave-heights"))
-        layerButtonList.add(LayerButtonView(baseContext, "Wave Periods", "wave-periods"))
-        layerButtonList.add(LayerButtonView(baseContext, "Swell 1 Heights", "swell-heights"))
-        layerButtonList.add(LayerButtonView(baseContext, "Swell Periods", "swell-periods"))
-        layerButtonList.add(LayerButtonView(baseContext, "Swell 2 Heights", "swell2-heights"))
-        layerButtonList.add(LayerButtonView(baseContext, "Swell 2 Periods", "swell2-periods"))
-        layerButtonList.add(LayerButtonView(baseContext, "Swell 3 Heights", "swell3-heights"))
-        layerButtonList.add(LayerButtonView(baseContext, "Swell 3 Periods", "swell3-periods"))
-        layerButtonList.add(LayerButtonView(baseContext, "Storm Surge", "storm-surge"))
-        layerButtonList.add(LayerButtonView(baseContext, "Tide Heights", "tide-heights"))
+        layerButtonList.add(LayerButtonView(baseContext, "Sea Surface Temps", WeatherService.SST(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Currents: Fill", WeatherService.OceanCurrents(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Currents: Particles", WeatherService.OceanCurrentsParticles(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Wave Heights", WeatherService.WaveHeights(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Wave Periods", WeatherService.WavePeriods(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Swell 1 Heights", WeatherService.SwellHeights(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Swell Periods", WeatherService.SwellPeriods(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Swell 2 Heights", WeatherService.SwellHeights2(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Swell 2 Periods", WeatherService.SwellPeriods2(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Swell 3 Heights", WeatherService.SwellHeights3(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Swell 3 Periods", WeatherService.SwellPeriods3(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Storm Surge", WeatherService.StormSurge(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Tide Heights", WeatherService.TideHeights(mapController.service)))
 
         layerButtonList.add(createHeadingTextView("Air Quality", baseContext))
-        layerButtonList.add(LayerButtonView(baseContext, "Air Quality Index", "air-quality-index"))
-        layerButtonList.add(LayerButtonView(baseContext, "AQI Categories", "air-quality-index-categories"))
-        layerButtonList.add(LayerButtonView(baseContext, "Health Index", "air-quality-health"))
-        layerButtonList.add(LayerButtonView(baseContext, "AQI: China", "air-quality-index-china"))
-        layerButtonList.add(LayerButtonView(baseContext, "AQI: India", "air-quality-index-india"))
-        layerButtonList.add(LayerButtonView(baseContext, "AQI: Common", "air-quality-index-caqi-categories"))
-        layerButtonList.add(LayerButtonView(baseContext, "AQI: European", "air-quality-eaqi-categories"))
-        layerButtonList.add(LayerButtonView(baseContext, "AQI: UK", "air-quality-index-uk-daqi-categories"))
-        layerButtonList.add(LayerButtonView(baseContext, "AQI: Germany", "air-quality-index-uba-daqi-categories"))
-        layerButtonList.add(LayerButtonView(baseContext, "AQI: Korea", "air-quality-index-cai-categories"))
-        layerButtonList.add(LayerButtonView(baseContext, "Carbon Monoxide (CO)", "air-quality-co"))
-        layerButtonList.add(LayerButtonView(baseContext, "Nitrogen Monoxide (NO)", "air-quality-no"))
-        layerButtonList.add(LayerButtonView(baseContext, "Nitrogen Dioxide (NO2)", "air-quality-no2"))
-        layerButtonList.add(LayerButtonView(baseContext, "Ozone (O3)", "air-quality-o3"))
-        layerButtonList.add(LayerButtonView(baseContext, "Sulfur Dioxide (SO2)", "air-quality-so2"))
-        layerButtonList.add(LayerButtonView(baseContext, "Particle Pollution (PM 2.5)", "air-quality-pm2p5"))
-        layerButtonList.add(LayerButtonView(baseContext, "Particle Pollution (PM 10)", "air-quality-pm10"))
+        layerButtonList.add(LayerButtonView(baseContext, "Air Quality Index", WeatherService.AirQualityIndex(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "AQI Categories", WeatherService.AirQualityIndexCategories(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Health Index", WeatherService.HealthIndex(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "AQI: China", WeatherService.AirQualityIndexChina(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "AQI: India", WeatherService.AirQualityIndexIndia(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "AQI: Common", WeatherService.AirQualityIndexCommon(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "AQI: European", WeatherService.AirQualityIndexEuropean(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "AQI: UK", WeatherService.AirQualityIndexUK(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "AQI: Germany", WeatherService.AirQualityIndexGermany(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "AQI: Korea", WeatherService.AirQualityIndexKorea(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Carbon Monoxide (CO)", WeatherService.CarbonMonoxide(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Nitrogen Monoxide (NO)", WeatherService.NitricOxide(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Nitrogen Dioxide (NO2)", WeatherService.NitrogenDioxide(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Ozone (O3)", WeatherService.Ozone(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Sulfur Dioxide (SO2)", WeatherService.SulfurDioxide(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Particle Pollution (PM 2.5)", WeatherService.ParticulateMatter25Micron(mapController.service)))
+        layerButtonList.add(LayerButtonView(baseContext, "Particle Pollution (PM 10)", WeatherService.ParticulateMatter10Micron(mapController.service)))
 
         for (customView in layerButtonList) {
             if (customView is LayerButtonView) { // Add layer button
@@ -215,7 +236,6 @@ class MainActivity : AppCompatActivity() {
             } else { //Add category label
                 binding.outerLinearLayout.addView(customView)
             }
-
         }
     }
 }


### PR DESCRIPTION
✨ Features
Added support for fully stylable particle layers.
Improved handling for screen and device rotation.

🛠 Improvements
Smoother scrolling and zooming.
Updated colors scales for precipitation, ocean-currents and snow-depth.
Fixed particle transitions across tile boundaries.

🐞 Bug Fixes
Resolved an issue where the maximum number of world copies being rendered when zoomed out in landscape mode was clamped at 2.
Resolved issue with sporadic screen flashing at high zoom levels.
Fixed an issue where tiles across the anti-meridian from the center would be rendered at lower detail levels.
Fixed render lag for encoded raster data rendering relative to the underlying map layer during fast scrolling.

⚠️ Known Issues
Due to the way that earlier versions of Mapbox handle multiple world copies, please use Mapbox version 11.3.0+.
Radar layer does not depict precipitation types (mix, snow) yet.